### PR TITLE
Feat: Landing search page uses google search instead of geoapify

### DIFF
--- a/app/facades/places_facade.rb
+++ b/app/facades/places_facade.rb
@@ -2,11 +2,23 @@ class PlacesFacade
   # Target field arrays for each API. As place APIs are addedin the future,
   # they will have their own hash element to allow target_field_filter to format uniformly
   TARGET_FIELDS = {
-    geoapify_fields: %i[name formatted categories place_id lon lat image_data]
+    geoapify_fields: %i[name formatted categories place_id lon lat image_data],
+    google_api_fields: %i[name formatted categories place_id lon lat image_data]
   }.freeze
 
   def self.places(city_info, categories = nil, page = 0, search_radius = 2500)
-    geoapify_get_places(city_info, categories, page, search_radius)
+    if categories.nil?
+      pagetokens = []
+      if page.to_i.positive?
+        pagetokens = Rails.cache.read(:google_page_tokens)
+        return geoapify_get_places(city_info, categories, page, search_radius) unless pagetokens[page - 1].present?
+      end
+      response = google_get_places(city_info, pagetokens[page - 1])
+      Rails.cache.write(:google_page_tokens, pagetokens << response[:next_page_token], expires_in: 30.minutes)
+      response[:results]
+    else
+      geoapify_get_places(city_info, categories, page, search_radius)
+    end
   end
 
   # PRIVATE METHODS
@@ -15,6 +27,27 @@ class PlacesFacade
   def self.target_field_filter(properties, target_fields_key)
     properties.map do |hit|
       hit.select { |key, _value| TARGET_FIELDS[target_fields_key].include?(key) }
+    end
+  end
+
+  #  Google specific methods:
+  #  -------------------------------------------------------------------------
+  def self.google_get_places(city_info, page_token = nil)
+    response = GoogleService.get_city_places(city_info, page_token)
+    results = google_results_formatter(response[:results])
+    { results: target_field_filter(results, :google_api_fields), next_page_token: response[:next_page_token] }
+  end
+
+  def self.google_results_formatter(raw_hits)
+    raw_hits.map do |raw_hit|
+      raw_hit[:formatted] = "#{raw_hit[:name]}, #{raw_hit[:formatted_address]}"
+      raw_hit[:categories] = raw_hit[:types]
+      raw_hit[:place_id] = { source: 'google', place_id: raw_hit[:place_id] }
+      raw_hit[:lon] = raw_hit[:geometry][:location][:lng]
+      raw_hit[:lat] = raw_hit[:geometry][:location][:lat]
+      photo_url = GoogleService.get_photo_url(raw_hit[:photos][0][:photo_reference]) if raw_hit[:photos].present? && raw_hit[:photos][0].present? && raw_hit[:photos][0][:photo_reference].present?
+      raw_hit[:image_data] = { name: raw_hit[:name], photo_reference: photo_url.presence || 'NO_PHOTOS' }
+      raw_hit
     end
   end
 
@@ -44,8 +77,11 @@ class PlacesFacade
   end
 
   def self.get_detailed_information(id)
-    json = GeoapifyService.get_place_details(id)
-    json[:features][0][:properties]
+    # if id[:source] == 'google'
+    #   json = GoogleService.get_place_details(id[:place_id])
+    # end
+      json = GeoapifyService.get_place_details(id)
+      json[:features][0][:properties]
   end
 
   # END Geoapify methods

--- a/app/graphql/queries/fetch_place_details.rb
+++ b/app/graphql/queries/fetch_place_details.rb
@@ -1,34 +1,34 @@
 module Queries
-    class FetchPlaceDetails < Queries::BaseQuery
-      type Types::PlaceType, null: true
+  class FetchPlaceDetails < Queries::BaseQuery
+    type Types::PlaceType, null: true
 
-      argument :place_id, String, required: true
+    argument :place_id, String, required: true
 
-      def verify_contact(details)
-        if details[:contact].present?
-          return details[:contact][:phone].presence
-        else
-          return nil
-        end
-      end
-
-      def resolve(args)
-        details = PlacesFacade.get_detailed_information(args[:place_id])
-        image = ImageFacade.get_place_image_ref(details[:formatted])
-        {"place_id" => args[:place_id],
-         "name" => details[:name],
-         "city" => details[:city],
-         "state" => details[:state],
-         "country" => details[:country],
-         "phone" => verify_contact(details),
-         "website" => details[:website],
-         "hours" => details[:opening_hours],
-         "categories" => details[:categories],
-         "address" => details[:formatted],
-         "lat" => details[:lat],
-         "lon" => details[:lon],
-         "image_data" => image[:photo_reference]
-        }
+    def verify_contact(details)
+      if details[:contact].present?
+        return details[:contact][:phone].presence
+      else
+        return nil
       end
     end
+
+    def resolve(args)
+      details = PlacesFacade.get_detailed_information(args[:place_id])
+      image = ImageFacade.get_place_image_url(details[:formatted])
+      {"place_id" => args[:place_id],
+        "name" => details[:name],
+        "city" => details[:city],
+        "state" => details[:state],
+        "country" => details[:country],
+        "phone" => verify_contact(details),
+        "website" => details[:website],
+        "hours" => details[:opening_hours],
+        "categories" => details[:categories],
+        "address" => details[:formatted],
+        "lat" => details[:lat],
+        "lon" => details[:lon],
+        "image_data" => image[:photo_reference]
+      }
+    end
   end
+end

--- a/app/services/google_service.rb
+++ b/app/services/google_service.rb
@@ -8,6 +8,16 @@ class GoogleService
     JSON.parse(response.body, symbolize_names: true)
   end
 
+  def self.get_city_places(city_info, page_token)
+    response = conn.get("place/textsearch/json") do |f|
+      f.params['query'] = "things to do in #{city_info[:name]}"
+      f.params['language'] = 'en'
+      f.params['location'] = "#{city_info[:latitude]},#{city_info[:longitude]}"
+      (f.params['pagetoken'] = page_token) if page_token.present?
+    end
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
   def self.get_photo_url(reference)
     response = conn.get('place/photo') do |f|
       f.params['photo_reference'] = reference


### PR DESCRIPTION
# Description

Changes the get_places method to use the google text search places for the landing search page

Fixes #34 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tests general service and facade output
- [x] tests pagination using cached next_page_tokens from previous response

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Coverage is the same or higher than it was before my changes. If it's lower, it's because: 

## To-Dos

List anything that needs to be looked at or changed in future commits. Please include file path and line number if relevant.
- [ ] Fix all the stuff relating to single places to accept google place_ids as well as geoapify ones. 
- [ ] Make all place ids nested within a hash that also contains their source:
    `{ source: 'google' or 'geopapify', place_id: <place_id> }`
