### PR TITLE
Switch to google places

### DIFF
--- a/app/facades/places_facade.rb
+++ b/app/facades/places_facade.rb
@@ -3,21 +3,23 @@ class PlacesFacade
   # they will have their own hash element to allow target_field_filter to format uniformly
   TARGET_FIELDS = {
     geoapify_fields: %i[name formatted categories place_id lon lat image_data],
-    google_api_fields: %i[name formatted categories place_id lon lat image_data]
+    google_api_fields: %i[name formatted categories place_id lon lat image_data next_page_token]
   }.freeze
 
-  def self.places(city_info, categories = nil, page = 0, search_radius = 2500)
-    if categories.nil?
-      pagetokens = []
-      if page.to_i.positive?
-        pagetokens = Rails.cache.read(:google_page_tokens)
-        return geoapify_get_places(city_info, categories, page, search_radius) unless pagetokens[page - 1].present?
-      end
-      response = google_get_places(city_info, pagetokens[page - 1])
-      Rails.cache.write(:google_page_tokens, pagetokens << response[:next_page_token], expires_in: 30.minutes)
-      response[:results]
+  def self.places(city_info, categories: nil, page_token: nil, search_type: "google", search_radius: 2500)
+    if search_type == "geoapify"
+      geoapify_get_places(city_info, categories, search_radius)
     else
-      geoapify_get_places(city_info, categories, page, search_radius)
+      google_get_places(city_info, categories, page_token)
+    end
+  end
+
+  def self.get_detailed_information(id, source: 'google')
+    if source == 'geoapify'
+      details = GeoapifyService.get_place_details(id)
+      details[:features][0][:properties]
+    else
+      GoogleService.get_place_details(id)
     end
   end
 
@@ -30,22 +32,25 @@ class PlacesFacade
     end
   end
 
+
   #  Google specific methods:
   #  -------------------------------------------------------------------------
-  def self.google_get_places(city_info, page_token = nil)
-    response = GoogleService.get_city_places(city_info, page_token)
-    results = google_results_formatter(response[:results])
-    { results: target_field_filter(results, :google_api_fields), next_page_token: response[:next_page_token] }
+  def self.google_get_places(city_info, categories, page_token)
+    response = GoogleService.get_city_places(city_info, categories, page_token)
+    results = google_results_formatter(response[:results], response[:next_page_token])
+    target_field_filter(results, :google_api_fields)
   end
 
-  def self.google_results_formatter(raw_hits)
+  def self.google_results_formatter(raw_hits, next_page_token)
     raw_hits.map do |raw_hit|
       raw_hit[:formatted] = "#{raw_hit[:name]}, #{raw_hit[:formatted_address]}"
       raw_hit[:categories] = raw_hit[:types]
-      raw_hit[:place_id] = { source: 'google', place_id: raw_hit[:place_id] }
+      raw_hit[:next_page_token] = next_page_token
       raw_hit[:lon] = raw_hit[:geometry][:location][:lng]
       raw_hit[:lat] = raw_hit[:geometry][:location][:lat]
-      photo_url = GoogleService.get_photo_url(raw_hit[:photos][0][:photo_reference]) if raw_hit[:photos].present? && raw_hit[:photos][0].present? && raw_hit[:photos][0][:photo_reference].present?
+      if raw_hit[:photos].present? && raw_hit[:photos][0].present? && raw_hit[:photos][0][:photo_reference].present?
+        photo_url = GoogleService.get_photo_url(raw_hit[:photos][0][:photo_reference])
+      end
       raw_hit[:image_data] = { name: raw_hit[:name], photo_reference: photo_url.presence || 'NO_PHOTOS' }
       raw_hit
     end
@@ -55,7 +60,7 @@ class PlacesFacade
   #  -------------------------------------------------------------------------
 
   # Manager method. The symbol :geoapify_fields is stored in TARGET_FIELDS on line 4
-  def self.geoapify_get_places(city_info, categories, page, search_radius)
+  def self.geoapify_get_places(city_info, categories, page = 0, search_radius)
     raw_hits = geoapify_populate_results(city_info, categories, page, search_radius)
     properties = geoapify_flattener(raw_hits)
     target_field_filter(properties, :geoapify_fields)
@@ -74,14 +79,6 @@ class PlacesFacade
       raw_hit[:properties][:image_data] = ImageFacade.get_place_image_url(raw_hit[:properties][:formatted])
       raw_hit[:properties]
     end
-  end
-
-  def self.get_detailed_information(id)
-    # if id[:source] == 'google'
-    #   json = GoogleService.get_place_details(id[:place_id])
-    # end
-      json = GeoapifyService.get_place_details(id)
-      json[:features][0][:properties]
   end
 
   # END Geoapify methods

--- a/app/graphql/queries/fetch_places.rb
+++ b/app/graphql/queries/fetch_places.rb
@@ -13,7 +13,7 @@ module Queries
       city_info = GeocodingFacade.city_info(args.delete(:city), args.delete(:country))
       places = PlacesFacade.places(city_info, **args)
 
-      hits = places.each_with_object([]) do |place, array|
+      places.each_with_object([]) do |place, array|
         array << {
           'name' => place[:name].presence || place[:formatted],
           'address' => place[:formatted],

--- a/app/graphql/queries/fetch_places.rb
+++ b/app/graphql/queries/fetch_places.rb
@@ -5,14 +5,15 @@ module Queries
     argument :city, String, required: true
     argument :country, String, required: true
     argument :categories, [String], required: false, default_value: nil
-    argument :page, Integer, required: false, default_value: 0
-    argument :radius, Integer, required: false, default_value: 2500
+    argument :page_token, String, required: false, default_value: nil
+    argument :search_type, String, required: false, default_value: "google"
+    argument :search_radius, Integer, required: false, default_value: 2500
 
     def resolve(args)
-      city_info = GeocodingFacade.city_info(args[:city], args[:country])
-      places = PlacesFacade.places(city_info, args[:categories], args[:page], args[:radius])
+      city_info = GeocodingFacade.city_info(args.delete(:city), args.delete(:country))
+      places = PlacesFacade.places(city_info, **args)
 
-      places.each_with_object([]) do |place, array|
+      hits = places.each_with_object([]) do |place, array|
         array << {
           'name' => place[:name].presence || place[:formatted],
           'address' => place[:formatted],
@@ -20,7 +21,8 @@ module Queries
           'place_id' => place[:place_id],
           'city' => city_info[:city], 'country' => city_info[:country],
           'lat' => place[:lat], 'lon' => place[:lon],
-          'image_data' => place[:image_data].to_s
+          'image_data' => place[:image_data],
+          'next_page_token' => place[:next_page_token]
         }
       end
     end

--- a/app/graphql/types/place_type.rb
+++ b/app/graphql/types/place_type.rb
@@ -15,5 +15,6 @@ module Types
     field :hours, String, null: true
     field :website, String, null: true
     field :image_data, String, null: true
+    field :next_page_token, String, null: true
   end
 end

--- a/app/services/google_service.rb
+++ b/app/services/google_service.rb
@@ -1,6 +1,6 @@
 class GoogleService
   def self.find_place(address, fields = '')
-    response = conn.get("place/findplacefromtext/json") do |f|
+    response = conn.get('place/findplacefromtext/json') do |f|
       f.params['fields'] = fields
       f.params['inputtype'] = 'textquery'
       f.params['input'] = address
@@ -8,9 +8,14 @@ class GoogleService
     JSON.parse(response.body, symbolize_names: true)
   end
 
-  def self.get_city_places(city_info, page_token)
-    response = conn.get("place/textsearch/json") do |f|
-      f.params['query'] = "things to do in #{city_info[:name]}"
+  def self.get_city_places(city_info, categories, page_token)
+    query_string = if categories
+                     "best #{categories.join(' ')} in #{city_info[:name]}"
+                   else
+                     "best things to do in #{city_info[:name]}"
+                   end
+    response = conn.get('place/textsearch/json') do |f|
+      f.params['query'] = query_string
       f.params['language'] = 'en'
       f.params['location'] = "#{city_info[:latitude]},#{city_info[:longitude]}"
       (f.params['pagetoken'] = page_token) if page_token.present?

--- a/app/services/google_service.rb
+++ b/app/services/google_service.rb
@@ -10,9 +10,9 @@ class GoogleService
 
   def self.get_city_places(city_info, categories, page_token)
     query_string = if categories
-                     "best #{categories.join(' ')} in #{city_info[:name]}"
+                     "best #{categories.join(' ')} in #{city_info[:name]}, #{city_info[:country]}"
                    else
-                     "best things to do in #{city_info[:name]}"
+                     "best things to do in #{city_info[:name]}, #{city_info[:country]}"
                    end
     response = conn.get('place/textsearch/json') do |f|
       f.params['query'] = query_string

--- a/spec/facades/places_facade_spec.rb
+++ b/spec/facades/places_facade_spec.rb
@@ -70,7 +70,9 @@ RSpec.describe PlacesFacade, :vcr do
           places_pg2 = PlacesFacade.places(city_info, page_token: places_pg1.first[:next_page_token])
 
           expect(places_pg2).to be_an Array
-
+          puts places_pg1
+          puts places_pg2
+          
           first_page_hit = places_pg1[0]
           hit = places_pg2[0]
 

--- a/spec/facades/places_facade_spec.rb
+++ b/spec/facades/places_facade_spec.rb
@@ -40,63 +40,15 @@ RSpec.describe PlacesFacade, :vcr do
   # end
 
   context 'google methods' do
-    describe '.get_places w/o categories (landing page)' do
-      it 'returns places from location in proper format' do
-        places = PlacesFacade.places(city_info)
+    describe ' - happy path - ' do
+      describe '.places w/o categories (landing page)' do
+        it 'returns places from location in proper format' do
+          places = PlacesFacade.places(city_info)
 
-        expect(places).to be_an Array
-
-        hit = places[0]
-
-        expect(hit).to be_a(Hash)
-        expect(hit.keys).to include(:name, :lon, :lat, :formatted, :categories, :place_id, :image_data, :next_page_token)
-        expect(hit[:name]).to be_a(String)
-        expect(hit[:formatted]).to be_a(String)
-        expect(hit[:categories]).to be_a(Array)
-        expect(hit[:categories][0]).to be_a(String)
-        expect(hit[:place_id]).to be_a(String)
-        expect(hit[:image_data]).to be_a Hash
-        expect(hit[:image_data].keys).to eq(%i[name photo_reference])
-        expect(hit[:next_page_token]).to be_a String
-        expect(hit[:image_data][:name]).to be_a(String)
-        expect(hit[:image_data][:photo_reference]).to be_a(String)
-        expect(hit[:lat]).to be_a(Float)
-        expect(hit[:lon]).to be_a(Float)
-      end
-
-      it 'can paginate and still returns places from location in proper format' do
-        places_pg1 = PlacesFacade.places(city_info)
-        places_pg2 = PlacesFacade.places(city_info, page_token: places_pg1.first[:next_page_token])
-
-        expect(places_pg2).to be_an Array
-
-        first_page_hit = places_pg1[0]
-        hit = places_pg2[0]
-
-        expect(hit).to_not eq(first_page_hit)
-
-        expect(hit).to be_a(Hash)
-        expect(hit.keys).to include(:name, :lon, :lat, :formatted, :categories, :place_id, :image_data, :next_page_token)
-        expect(hit[:name]).to be_a(String)
-        expect(hit[:formatted]).to be_a(String)
-        expect(hit[:categories]).to be_a(Array)
-        expect(hit[:categories][0]).to be_a(String)
-        expect(hit[:place_id]).to be_a(String)
-        expect(hit[:image_data]).to be_a Hash
-        expect(hit[:image_data].keys).to eq(%i[name photo_reference])
-        expect(hit[:image_data][:name]).to be_a(String)
-        expect(hit[:image_data][:photo_reference]).to be_a(String)
-        expect(hit[:lat]).to be_a(Float)
-        expect(hit[:lon]).to be_a(Float)
-      end
-
-      describe '.get_places w/ categories' do
-        it 'returns new places that match the categories' do
-          places = PlacesFacade.places(city_info, categories: ['restaurants'])
           expect(places).to be_an Array
-  
+
           hit = places[0]
-  
+
           expect(hit).to be_a(Hash)
           expect(hit.keys).to include(:name, :lon, :lat, :formatted, :categories, :place_id, :image_data, :next_page_token)
           expect(hit[:name]).to be_a(String)
@@ -111,6 +63,73 @@ RSpec.describe PlacesFacade, :vcr do
           expect(hit[:image_data][:photo_reference]).to be_a(String)
           expect(hit[:lat]).to be_a(Float)
           expect(hit[:lon]).to be_a(Float)
+        end
+
+        it 'can paginate and still returns places from location in proper format' do
+          places_pg1 = PlacesFacade.places(city_info)
+          places_pg2 = PlacesFacade.places(city_info, page_token: places_pg1.first[:next_page_token])
+
+          expect(places_pg2).to be_an Array
+
+          first_page_hit = places_pg1[0]
+          hit = places_pg2[0]
+
+          expect(hit).to_not eq(first_page_hit)
+
+          expect(hit).to be_a(Hash)
+          expect(hit.keys).to include(:name, :lon, :lat, :formatted, :categories, :place_id, :image_data, :next_page_token)
+          expect(hit[:name]).to be_a(String)
+          expect(hit[:formatted]).to be_a(String)
+          expect(hit[:categories]).to be_a(Array)
+          expect(hit[:categories][0]).to be_a(String)
+          expect(hit[:place_id]).to be_a(String)
+          expect(hit[:image_data]).to be_a Hash
+          expect(hit[:image_data].keys).to eq(%i[name photo_reference])
+          expect(hit[:image_data][:name]).to be_a(String)
+          expect(hit[:image_data][:photo_reference]).to be_a(String)
+          expect(hit[:lat]).to be_a(Float)
+          expect(hit[:lon]).to be_a(Float)
+        end
+      end
+
+      describe 'places w/ categories' do
+        it 'returns new places that match the categories' do
+          places = PlacesFacade.places(city_info, categories: ['restaurants'])
+          expect(places).to be_an Array
+
+          hit = places[0]
+
+          expect(hit).to be_a(Hash)
+          expect(hit.keys).to include(:name, :lon, :lat, :formatted, :categories, :place_id, :image_data, :next_page_token)
+          expect(hit[:name]).to be_a(String)
+          expect(hit[:formatted]).to be_a(String)
+          expect(hit[:categories]).to be_a(Array)
+          expect(hit[:categories][0]).to be_a(String)
+          expect(hit[:place_id]).to be_a(String)
+          expect(hit[:image_data]).to be_a Hash
+          expect(hit[:image_data].keys).to eq(%i[name photo_reference])
+          expect(hit[:next_page_token]).to be_a String
+          expect(hit[:image_data][:name]).to be_a(String)
+          expect(hit[:image_data][:photo_reference]).to be_a(String)
+          expect(hit[:lat]).to be_a(Float)
+          expect(hit[:lon]).to be_a(Float)
+        end
+      end
+    end
+
+    describe ' - sad path - ' do
+      describe 'can still correctly .places with shared international names' do
+        it 'returns places from location in proper format' do
+          city_info = GeocodingFacade.city_info("Paris", "USA")
+          places = PlacesFacade.places(city_info)
+
+          expect(places).to be_an Array
+
+          hit = places[0]
+
+          expect(hit).to be_a(Hash)
+          expect(hit.keys).to include(:name, :lon, :lat, :formatted, :categories, :place_id, :image_data, :next_page_token)
+          expect(hit[:name].include?("TX"))
         end
       end
     end

--- a/spec/facades/places_facade_spec.rb
+++ b/spec/facades/places_facade_spec.rb
@@ -70,9 +70,10 @@ RSpec.describe PlacesFacade, :vcr do
           places_pg2 = PlacesFacade.places(city_info, page_token: places_pg1.first[:next_page_token])
 
           expect(places_pg2).to be_an Array
+
           puts places_pg1
           puts places_pg2
-          
+
           first_page_hit = places_pg1[0]
           hit = places_pg2[0]
 

--- a/spec/facades/places_facade_spec.rb
+++ b/spec/facades/places_facade_spec.rb
@@ -71,27 +71,12 @@ RSpec.describe PlacesFacade, :vcr do
 
           expect(places_pg2).to be_an Array
 
-          puts places_pg1
-          puts places_pg2
+          first_page_hit = places_pg1.first
+          second_page_hit = places_pg2.first
 
-          first_page_hit = places_pg1[0]
-          hit = places_pg2[0]
+          expect(places_pg1).to_not include(second_page_hit)
+          expect(places_pg2).to_not include(first_page_hit)
 
-          expect(hit).to_not eq(first_page_hit)
-
-          expect(hit).to be_a(Hash)
-          expect(hit.keys).to include(:name, :lon, :lat, :formatted, :categories, :place_id, :image_data, :next_page_token)
-          expect(hit[:name]).to be_a(String)
-          expect(hit[:formatted]).to be_a(String)
-          expect(hit[:categories]).to be_a(Array)
-          expect(hit[:categories][0]).to be_a(String)
-          expect(hit[:place_id]).to be_a(String)
-          expect(hit[:image_data]).to be_a Hash
-          expect(hit[:image_data].keys).to eq(%i[name photo_reference])
-          expect(hit[:image_data][:name]).to be_a(String)
-          expect(hit[:image_data][:photo_reference]).to be_a(String)
-          expect(hit[:lat]).to be_a(Float)
-          expect(hit[:lon]).to be_a(Float)
         end
       end
 

--- a/spec/facades/places_facade_spec.rb
+++ b/spec/facades/places_facade_spec.rb
@@ -71,6 +71,9 @@ RSpec.describe PlacesFacade, :vcr do
 
           expect(places_pg2).to be_an Array
 
+          puts places_pg1
+          puts places_pg2
+
           first_page_hit = places_pg1[0]
           hit = places_pg2[0]
 

--- a/spec/facades/places_facade_spec.rb
+++ b/spec/facades/places_facade_spec.rb
@@ -71,9 +71,6 @@ RSpec.describe PlacesFacade, :vcr do
 
           expect(places_pg2).to be_an Array
 
-          puts places_pg1
-          puts places_pg2
-
           first_page_hit = places_pg1[0]
           hit = places_pg2[0]
 

--- a/spec/facades/places_facade_spec.rb
+++ b/spec/facades/places_facade_spec.rb
@@ -6,38 +6,38 @@ RSpec.describe PlacesFacade, :vcr do
       state: 'Ile-de-France' }
   end
 
-  context 'pagination' do
-    it 'doesnt repeat or exclude results between pages' do
-      response = Faraday.get('https://api.geoapify.com/v2/places') do |f|
-        f.params['categories'] = 'tourism.sights'
-        f.params['bias'] = 'proximity:2.3200410217200766,48.8588897'
-        f.params['filter'] = 'circle:2.3200410217200766,48.8588897,2500'
-        f.params['limit'] = '40'
-        f.params['apiKey'] = ENV['places_api_key']
-      end
+  # context 'pagination' do
+    # it 'doesnt repeat or exclude results between pages' do
+    #   response = Faraday.get('https://api.geoapify.com/v2/places') do |f|
+    #     f.params['categories'] = 'tourism.sights'
+    #     f.params['bias'] = 'proximity:2.3200410217200766,48.8588897'
+    #     f.params['filter'] = 'circle:2.3200410217200766,48.8588897,2500'
+    #     f.params['limit'] = '40'
+    #     f.params['apiKey'] = ENV['places_api_key']
+    #   end
 
-      target_fields = %i[name formatted categories place_id lon lat]
+  #     target_fields = %i[name formatted categories place_id lon lat]
 
-      parsed = JSON.parse(response.body, symbolize_names: true)[:features]
-                   .map { |hit| hit[:properties].select { |key, _value| target_fields.include?(key) } }
+  #     parsed = JSON.parse(response.body, symbolize_names: true)[:features]
+  #                  .map { |hit| hit[:properties].select { |key, _value| target_fields.include?(key) } }
 
-      page_1 = PlacesFacade.places(city_info, ['tourism.sights'], 0).map do |hit|
-        hit.reject do |k, _v|
-          k == :image_data
-        end
-      end
-      page_2 = PlacesFacade.places(city_info, ['tourism.sights'], 1).map do |hit|
-        hit.reject do |k, _v|
-          k == :image_data
-        end
-      end
+  #     page_1 = PlacesFacade.places(city_info, ['tourism.sights'], 0).map do |hit|
+  #       hit.reject do |k, _v|
+  #         k == :image_data
+  #       end
+  #     end
+  #     page_2 = PlacesFacade.places(city_info, ['tourism.sights'], 1).map do |hit|
+  #       hit.reject do |k, _v|
+  #         k == :image_data
+  #       end
+  #     end
 
-      parsed.each
-      expect(page_1).to eq(parsed.take(20))
-      expect(page_2).to eq(parsed.last(20))
-      expect(page_1.concat(page_2)).to eq(parsed)
-    end
-  end
+  #     parsed.each
+  #     expect(page_1).to eq(parsed.take(20))
+  #     expect(page_2).to eq(parsed.last(20))
+  #     expect(page_1.concat(page_2)).to eq(parsed)
+  #   end
+  # end
 
   context 'google methods' do
     describe '.get_places w/o categories (landing page)' do
@@ -49,16 +49,15 @@ RSpec.describe PlacesFacade, :vcr do
         hit = places[0]
 
         expect(hit).to be_a(Hash)
-        expect(hit.keys).to eq(%i[name place_id formatted categories lon lat image_data])
+        expect(hit.keys).to include(:name, :lon, :lat, :formatted, :categories, :place_id, :image_data, :next_page_token)
         expect(hit[:name]).to be_a(String)
         expect(hit[:formatted]).to be_a(String)
         expect(hit[:categories]).to be_a(Array)
         expect(hit[:categories][0]).to be_a(String)
-        expect(hit[:place_id]).to be_a(Hash)
-        expect(hit[:place_id].keys).to eq(%i[source place_id])
-        expect(hit[:place_id][:source]).to eq('google')
+        expect(hit[:place_id]).to be_a(String)
         expect(hit[:image_data]).to be_a Hash
         expect(hit[:image_data].keys).to eq(%i[name photo_reference])
+        expect(hit[:next_page_token]).to be_a String
         expect(hit[:image_data][:name]).to be_a(String)
         expect(hit[:image_data][:photo_reference]).to be_a(String)
         expect(hit[:lat]).to be_a(Float)
@@ -67,7 +66,7 @@ RSpec.describe PlacesFacade, :vcr do
 
       it 'can paginate and still returns places from location in proper format' do
         places_pg1 = PlacesFacade.places(city_info)
-        places_pg2 = PlacesFacade.places(city_info, nil, 1)
+        places_pg2 = PlacesFacade.places(city_info, page_token: places_pg1.first[:next_page_token])
 
         expect(places_pg2).to be_an Array
 
@@ -77,35 +76,7 @@ RSpec.describe PlacesFacade, :vcr do
         expect(hit).to_not eq(first_page_hit)
 
         expect(hit).to be_a(Hash)
-        expect(hit.keys).to include(:name, :lon, :lat, :formatted, :categories, :place_id, :image_data)
-        expect(hit[:name]).to be_a(String)
-        expect(hit[:formatted]).to be_a(String)
-        expect(hit[:categories]).to be_a(Array)
-        expect(hit[:categories][0]).to be_a(String)
-        expect(hit[:place_id]).to be_a(Hash)
-        expect(hit[:place_id].keys).to eq(%i[source place_id])
-        expect(hit[:place_id][:source]).to eq('google')
-        expect(hit[:image_data]).to be_a Hash
-        expect(hit[:image_data].keys).to eq(%i[name photo_reference])
-        expect(hit[:image_data][:name]).to be_a(String)
-        expect(hit[:image_data][:photo_reference]).to be_a(String)
-        expect(hit[:lat]).to be_a(Float)
-        expect(hit[:lon]).to be_a(Float)
-      end
-    end
-  end
-
-  context 'geoapify methods' do
-    describe '.get_places with category' do
-      it 'returns places from location' do
-        places = PlacesFacade.places(city_info, ['tourism.sights'])
-
-        expect(places).to be_an Array
-
-        hit = places[0]
-
-        expect(hit).to be_a(Hash)
-        expect(hit.keys).to eq(%i[name lon lat formatted categories place_id image_data])
+        expect(hit.keys).to include(:name, :lon, :lat, :formatted, :categories, :place_id, :image_data, :next_page_token)
         expect(hit[:name]).to be_a(String)
         expect(hit[:formatted]).to be_a(String)
         expect(hit[:categories]).to be_a(Array)
@@ -119,54 +90,104 @@ RSpec.describe PlacesFacade, :vcr do
         expect(hit[:lon]).to be_a(Float)
       end
 
-      it 'doesnt repeat or exclude results between pages' do
-        response = Faraday.get('https://api.geoapify.com/v2/places') do |f|
-          f.params['categories'] = 'tourism.sights'
-          f.params['bias'] = 'proximity:2.3200410217200766,48.8588897'
-          f.params['filter'] = 'circle:2.3200410217200766,48.8588897,2500'
-          f.params['limit'] = '40'
-          f.params['apiKey'] = ENV['places_api_key']
+      describe '.get_places w/ categories' do
+        it 'returns new places that match the categories' do
+          places = PlacesFacade.places(city_info, categories: ['restaurants'])
+          expect(places).to be_an Array
+  
+          hit = places[0]
+  
+          expect(hit).to be_a(Hash)
+          expect(hit.keys).to include(:name, :lon, :lat, :formatted, :categories, :place_id, :image_data, :next_page_token)
+          expect(hit[:name]).to be_a(String)
+          expect(hit[:formatted]).to be_a(String)
+          expect(hit[:categories]).to be_a(Array)
+          expect(hit[:categories][0]).to be_a(String)
+          expect(hit[:place_id]).to be_a(String)
+          expect(hit[:image_data]).to be_a Hash
+          expect(hit[:image_data].keys).to eq(%i[name photo_reference])
+          expect(hit[:next_page_token]).to be_a String
+          expect(hit[:image_data][:name]).to be_a(String)
+          expect(hit[:image_data][:photo_reference]).to be_a(String)
+          expect(hit[:lat]).to be_a(Float)
+          expect(hit[:lon]).to be_a(Float)
         end
-
-        target_fields = %i[name formatted categories place_id lon lat]
-
-        parsed = JSON.parse(response.body, symbolize_names: true)[:features]
-                     .map { |hit| hit[:properties].select { |key, _value| target_fields.include?(key) } }
-
-        page_1 = PlacesFacade.places(city_info, ['tourism.sights'], 0).map do |hit|
-          hit.reject do |k, _v|
-            k == :image_data
-          end
-        end
-        page_2 = PlacesFacade.places(city_info, ['tourism.sights'], 1).map do |hit|
-          hit.reject do |k, _v|
-            k == :image_data
-          end
-        end
-
-        parsed.each
-        expect(page_1).to eq(parsed.take(20))
-        expect(page_2).to eq(parsed.last(20))
-        expect(page_1.concat(page_2)).to eq(parsed)
-      end
-    end
-
-    describe '.get_detailed_information' do
-      it 'returns details for a specific place based off id' do
-        city_info = { name: 'Olympia', latitude: 47.038360820746234, longitude: -122.93770133659231, country: 'US',
-                      state: 'Washington' }
-
-        places = PlacesFacade.places(city_info, categories = ['sport.fitness'])
-
-        hit = places[0]
-        id = hit[:place_id]
-        details = PlacesFacade.get_detailed_information(id)
-
-        expect(details).to have_key(:name)
-        expect(details[:name]).to eq('Planet Fitness')
       end
     end
   end
+
+  # context 'geoapify methods' do
+  #   describe '.get_places with category' do
+  #     it 'returns places from location' do
+  #       places = PlacesFacade.places(city_info, categories: ['tourism sights'])
+
+  #       expect(places).to be_an Array
+
+  #       hit = places[0]
+
+  #       expect(hit).to be_a(Hash)
+  #       expect(hit.keys).to eq(%i[name lon lat formatted categories place_id image_data])
+  #       expect(hit[:name]).to be_a(String)
+  #       expect(hit[:formatted]).to be_a(String)
+  #       expect(hit[:categories]).to be_a(Array)
+  #       expect(hit[:categories][0]).to be_a(String)
+  #       expect(hit[:place_id]).to be_a(String)
+  #       expect(hit[:image_data]).to be_a Hash
+  #       expect(hit[:image_data].keys).to eq(%i[name photo_reference])
+  #       expect(hit[:image_data][:name]).to be_a(String)
+  #       expect(hit[:image_data][:photo_reference]).to be_a(String)
+  #       expect(hit[:lat]).to be_a(Float)
+  #       expect(hit[:lon]).to be_a(Float)
+  #     end
+
+  #     it 'doesnt repeat or exclude results between pages' do
+  #       response = Faraday.get('https://api.geoapify.com/v2/places') do |f|
+  #         f.params['categories'] = 'tourism.sights'
+  #         f.params['bias'] = 'proximity:2.3200410217200766,48.8588897'
+  #         f.params['filter'] = 'circle:2.3200410217200766,48.8588897,2500'
+  #         f.params['limit'] = '40'
+  #         f.params['apiKey'] = ENV['places_api_key']
+  #       end
+
+  #       target_fields = %i[name formatted categories place_id lon lat]
+
+  #       parsed = JSON.parse(response.body, symbolize_names: true)[:features]
+  #                    .map { |hit| hit[:properties].select { |key, _value| target_fields.include?(key) } }
+
+  #       page_1 = PlacesFacade.places(city_info, ['tourism sights'], 0).map do |hit|
+  #         hit.reject do |k, _v|
+  #           k == :image_data
+  #         end
+  #       end
+  #       page_2 = PlacesFacade.places(city_info, ['tourism sights'], 1).map do |hit|
+  #         hit.reject do |k, _v|
+  #           k == :image_data
+  #         end
+  #       end
+
+  #       parsed.each
+  #       expect(page_1).to eq(parsed.take(20))
+  #       expect(page_2).to eq(parsed.last(20))
+  #       expect(page_1.concat(page_2)).to eq(parsed)
+  #     end
+  #   end
+
+  #   describe '.get_detailed_information' do
+  #     it 'returns details for a specific place based off id' do
+  #       city_info = { name: 'Olympia', latitude: 47.038360820746234, longitude: -122.93770133659231, country: 'US',
+  #                     state: 'Washington' }
+
+  #       places = PlacesFacade.places(city_info, categories: ['sport fitness'])
+
+  #       hit = places[0]
+  #       id = hit[:place_id]
+  #       details = PlacesFacade.get_detailed_information(id)
+
+  #       expect(details).to have_key(:name)
+  #       expect(details[:name]).to eq('Planet Fitness')
+  #     end
+  #   end
+  # end
 
   # Old test for auto expanding radius method
   # context 'expanding radius' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -80,5 +80,5 @@ VCR.configure do |config|
   config.filter_sensitive_data('google_key') { ENV['google_key'] }
   config.configure_rspec_metadata!
   config.allow_http_connections_when_no_cassette = true
-  config.default_cassette_options = { :re_record_interval => 7.days }
+  config.default_cassette_options = { :re_record_interval => 30.seconds }
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -80,5 +80,5 @@ VCR.configure do |config|
   config.filter_sensitive_data('google_key') { ENV['google_key'] }
   config.configure_rspec_metadata!
   config.allow_http_connections_when_no_cassette = true
-  config.default_cassette_options = { :re_record_interval => 7.days }
+  config.default_cassette_options = { :re_record_interval => 1.hour }
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -80,5 +80,5 @@ VCR.configure do |config|
   config.filter_sensitive_data('google_key') { ENV['google_key'] }
   config.configure_rspec_metadata!
   config.allow_http_connections_when_no_cassette = true
-  config.default_cassette_options = { :re_record_interval => 30.seconds }
+  config.default_cassette_options = { :re_record_interval => 7.days }
 end


### PR DESCRIPTION
# Description

This PR moves the brunt of our external API consumption to the google places API, as the geoapify one has lower relevance and frequently experiences outages. This also allows us to standardize out place IDs for the place detail pages. 

Summary of changes:

- A quick fix for pagination: Pagination is now mostly done on the front end. If you query for a next_page_token in the payload of a places query, every hit will have the same token (a string). By passing that token string back into the next query as `page_token: <token>`, further results can be loaded, all of them with a new next_page_token.

- All place IDs are now for Google and flattened to just strings, not hashes

- Added edge case testing for cities like Paris, TX that would incorrectly bring up results for Paris, France

- The category field of a query should now be more conversational (e.g. ["Restaurants", "Wheelchair accessible"] instead of ["tourism.sights"]. This technically also allows for user entered queries if they're passed in as category strings, but that hasn't been tested.

 

Fixes #49 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Temporarily disables geoapify tests since they're depreciated
- [x] Updates old facade tests to look for new fields and adapts them to pagination changes
- [x] Adds sad path tests for places facade

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] Coverage is the same or higher than it was before my changes. If it's lower, it's because: Depreciated geoapify code is bringing coverage down, I left it there in case we wanted to do anything else with it.

## To-Dos

- [ ] `submit documentation update PR`
- [ ] `work with front end to integrate changes`
